### PR TITLE
Query generation fix

### DIFF
--- a/api/src/app.py
+++ b/api/src/app.py
@@ -902,17 +902,37 @@ def retrieve_historical_data(historical_params: HistoricalQueryParams, api_key: 
     Raises:
         HTTPException: If the query parameters are malformed or an unexpected error occurs.
     """
-    
+
     # check if group_time has valid values
     if historical_params.group_time and historical_params.group_time not in ['P1D', 'P1W', 'P1M']:
         raise HTTPException(status_code=400, detail="Invalid group_time value")
-    
+
     # check if necessary fields are not empty
     if not historical_params.kpi or not historical_params.timeframe or not historical_params.machines:
         raise HTTPException(status_code=400, detail="Missing required fields")
 
+    # The database only supports the following fields for a KPI ID
+    # the others will need to be requested using the calculate KPI endpoint
+    valid_fields = {"sum", "min", "max", "avg"}
+    kpi_id = historical_params.kpi
+    kpi_name, field = None, None
+
+    # Check the last 3 characters of the KPI ID
+    # Extract the suffix to get the field
+    if kpi_id[-3:] in valid_fields:
+        # Find the last underscore
+        split_index = kpi_id.rfind("_")
+
+        # Dividi il nome del KPI
+        kpi_name = kpi_id[:split_index]
+        field = kpi_id[split_index + 1:]
+
+    # check if the kpi is valid and was split correctly
+    if not kpi_name or not field:
+        raise HTTPException(status_code=400, detail="Invalid KPI ID")
+
     # substitute square brackets with parentheses in machine list
-    historical_params.machines = tuple(historical_params.machines) 
+    historical_params.machines = tuple(historical_params.machines)
 
     # remove commas from machines string in case it's a single one
     if len(historical_params.machines) == 1:
@@ -923,26 +943,53 @@ def retrieve_historical_data(historical_params: HistoricalQueryParams, api_key: 
     try:
         # Build the query body
 
-        # group_time is optional and has values: 
+        # group_time is optional and has values:
         # 'P1D'for daily intervals
         # 'P1W' for weekly intervals
         # 'P1M' for monthly intervals.
-        
-        query =  """SELECT name, TIME_FORMAT(__time, 'yyyy-MM-dd') AS timeframe FROM \"timeseries\" WHERE kpi = '{}' AND '__time' >= '{}' AND __time < '{}' 
-                    AND asset_id IN {} GROUP BY 
+
+        ''' previous code
+        query = """SELECT name, TIME_FORMAT(__time, 'yyyy-MM-dd') AS timeframe FROM \"timeseries\" WHERE kpi = '{}' AND '__time' >= '{}' AND __time < '{}' 
+                    AND name IN {} GROUP BY 
         """.format(
             historical_params.kpi, historical_params.timeframe["start_date"],
             historical_params.timeframe["end_date"], machines
-            )
-        
+        )
+
         # append optional group by time clause
-        if historical_params.group_time :
+        if historical_params.group_time:
             query += f"""TIME_FLOOR(__time, '{historical_params.group_time}'),"""
-        
+
         query += "name, __time"
-        
+        '''
+
+        # Base SELECT and FROM
+        query = f"""
+                    SELECT name,
+                """
+
+        # Include time formatting only for time series (group_time is present)
+        if historical_params.group_time:
+            query += f"TIME_FORMAT(TIME_FLOOR(__time, '{historical_params.group_time}'), 'yyyy-MM-dd') AS \"timestamp\", "
+
+        # Add KPI field aggregation, since max,avg etc. are keywords, they need to be enclosed in double quotes
+        query += f"SUM(\"{field}\") AS {kpi_id} FROM \"timeseries\" WHERE kpi = '{kpi_name}'"
+
+        # Add WHERE clause for timeframe and machines
+        query += f"""
+                      AND __time >= TIMESTAMP '{historical_params.timeframe["start_date"]}'
+                      AND __time < TIMESTAMP '{historical_params.timeframe["end_date"]}'
+                      AND name IN {machines}
+                """
+
+        # Add GROUP BY clause
+        query += " GROUP BY name"
+        # Group by time if present
+        if historical_params.group_time:
+            query += f", TIME_FLOOR(__time, '{historical_params.group_time}')"
+
         # Execute the query
-        response = execute_druid_query(os.getenv('DRUID_QUERY_ENDPOINT'), {"query" : query})
+        response = execute_druid_query(os.getenv('DRUID_QUERY_ENDPOINT'), {"query": query})
         if response:
             print("Query response:", response)
         else:
@@ -951,7 +998,7 @@ def retrieve_historical_data(historical_params: HistoricalQueryParams, api_key: 
     except Exception as e:
         logging.error("Exception: %s", str(e))
         raise HTTPException(status_code=500, detail=str(e))
-    
+
     return response
 
 @app.get("/smartfactory/dummy")


### PR DESCRIPTION
Make the query filter over the machine names instead of the asset_ids.
Edit query generation to split up the kpi id into field and key. Add aggregated field to select (will sum over machines or sum over the time grouping) Removed time from select when no time grouping is made.

Please give it a quick test if you have the environment set, didn't manage to compose everything up so i tested only by executing this code with the parameters from my frontend code and then sending the query to postman.