### PR TITLE
Real charts (not for dashboards yet)

### DIFF
--- a/gui-panel/src/api/ApiService.ts
+++ b/gui-panel/src/api/ApiService.ts
@@ -112,12 +112,36 @@ interface KPIObject {
 }
 
 /**
+ * Interface KPIRequest, used by the calculateKPIValue API
+ *
+ * @param KPI_Name string - The KPI ID
+ * @param Machine_Name string (optional) - The machine ID
+ * @param Date_Start string (optional) - The start time
+ * @param Date_Finish string (optional) - The end time
+ */
+export interface KPIRequest {
+    KPI_Name: string,
+    Machine_Name?: string,
+    Date_Start?: string,
+    Date_Finish?: string
+}
+
+/**
  * Interface KPIValue
  * @param value string - The value of the KPI
  */
 interface KPIValue {
-    value: string;
+    Machine_Name: string,
+    Machine_Type: string,
+    KPI_Name: string,
+    Value: number,
+    Measure_Unit: string,
+    Date_Start: string,
+    Date_Finish: string,
+    Aggregator: string,
+    Forecast: boolean
 }
+
 
 /**
  * Interface ScheduleRequest
@@ -446,7 +470,7 @@ export const interactWithAgent = async (userId: string, userInput: string): Prom
 };
 
 /**
- * API POST used to get the KPIs
+ * API GET used to get the KPIs
  * @returns KPIObject - Promise will return the KPIs
  */
 export const retrieveKPIs = async (): Promise<KPIObject[]> => {
@@ -468,29 +492,21 @@ export const retrieveKPIs = async (): Promise<KPIObject[]> => {
 };
 
 /**
- * API GET used to calculate the KPI value
- * @param kpiId string - The KPI ID
- * @param machineId string (optional) - The machine ID
- * @param startTime string (optional) - The start time
- * @param endTime string (optional) - The end time
+ * API POST used to calculate the KPI value
+ * @param requests KPIRequest[] - The KPI request list
  * @returns KPIValue - The KPI value
  */
-export const calculateKPIValue = async (
-    kpiId: string,
-    machineId?: string,
-    startTime?: string,
-    endTime?: string
-): Promise<KPIValue> => {
+export const calculateKPIValue = async (requests: KPIRequest[]): Promise<KPIValue[]> => {
     try {
-        const response = await axios.get<KPIValue>(
-            `${BASE_URL}/smartfactory/${kpiId}/calculate`,
+        const response = await axios.post<KPIValue[]>(
+            `${BASE_URL}/smartfactory/calculate`,
+            {requests},
             {
-                params: {machineId, startTime, endTime},
                 headers: {
                     "Content-Type": "application/json",
                     "x-api-key": API_KEY,
                 },
-            }
+            },
         );
         return response.data;
     } catch (error: any) {

--- a/gui-panel/src/api/DataStructures.tsx
+++ b/gui-panel/src/api/DataStructures.tsx
@@ -108,7 +108,6 @@ export class KPI {
 
     static decodeGroups(groups: Record<string, Record<string, any>>): KPI[] {
         const kpis: KPI[] = [];
-
         Object.entries(groups).forEach(([groupName, metrics]) => {
             Object.entries(metrics).forEach(([metricName, metricData]) => {
                 if (
@@ -116,13 +115,10 @@ export class KPI {
                     typeof metricData.description !== "string" ||
                     typeof metricData.unit_measure !== "string" ||
                     typeof metricData.type !== "string" ||
-                    typeof metricData.forecastable !== "boolean"
+                    (metricData.forecastable && typeof metricData.forecastable !== "boolean")
                 ) {
                     throw new Error(`Invalid KPI structure in group ${groupName}, metric ${metricName}`);
                 }
-
-                // if the metricName contains _med or _std set forecastable to false
-                metricData.forecastable = metricData.forecastable && !metricName.includes("_med") && !metricName.includes("_std");
 
                 // reformat kpi name with regex
                 // if followed by _avg, _min, _max, _sum, _med change it to (Avg), (Min), (Max), (Sum), (Med)
@@ -147,7 +143,7 @@ export class KPI {
                     metricName, // Metric name as the display name
                     metricData.description,
                     metricData.unit_measure, // Use unit_measure for unit
-                    metricData.forecastable // Forecastable flag
+                    metricData.forecastable ? metricData.forecastable : false // Forecastable flag
                 );
                 kpis.push(kpi);
             });

--- a/gui-panel/src/api/PersistentDataManager.tsx
+++ b/gui-panel/src/api/PersistentDataManager.tsx
@@ -2,6 +2,7 @@
 import {DashboardFolder, DashboardLayout, KPI, Machine} from "./DataStructures";
 import axios from "axios";
 import EventEmitter from "events";
+import {dummyCheck, retrieveKPIs, retrieveMachines} from "./ApiService";
 
 export async function loadFromApi<T>(apiEndpoint: string, decoder: (json: Record<string, any>) => T): Promise<T[]> {
     try {
@@ -71,22 +72,37 @@ class DataManager {
     }
 
     async initialize(): Promise<void> {
+        let ping = true;
         try {
-            this.kpiList = await loadFromLocal('/mockData/kpis.json', KPI.decodeGroups).then(
-                kpiToUnwrap => kpiToUnwrap[0] || [],
-                error => {
-                    console.error("Error loading kpis:", error);
-                    return [];
-                }
-            );
+            //try to connect  to dummy, if it fails, load from local
+            await dummyCheck();
+            console.log("Ping to dummy successful.");
+        } catch (error) {
+            console.error("Error connecting to dummy:", error);
+            ping = false;
+        }
+        try {
+            if (ping) {
+                this.kpiList = await retrieveKPIs();
+                this.machineList = await retrieveMachines();
+            } else {
 
-            this.machineList = await loadFromLocal('/mockData/machines.json', Machine.decodeGroups).then(
-                kpiToUnwrap => kpiToUnwrap[0] || [],
-                error => {
-                    console.error("Error loading kpis:", error);
-                    return [];
-                }
-            );
+                this.kpiList = await loadFromLocal('/mockData/kpis.json', KPI.decodeGroups).then(
+                    kpiToUnwrap => kpiToUnwrap[0] || [],
+                    error => {
+                        console.error("Error loading kpis:", error);
+                        return [];
+                    }
+                );
+
+                this.machineList = await loadFromLocal('/mockData/machines.json', Machine.decodeGroups).then(
+                    machineToUnwrap => machineToUnwrap[0] || [],
+                    error => {
+                        console.error("Error loading kpis:", error);
+                        return [];
+                    }
+                );
+            }
 
             this.dashboards = await loadFromLocal('/mockData/dashboards.json', DashboardFolder.decode).then(
                 dashboards => dashboards[0]?.children || [],

--- a/gui-panel/src/components/Chart/ForecastingChart.tsx
+++ b/gui-panel/src/components/Chart/ForecastingChart.tsx
@@ -93,7 +93,7 @@ const ForeChart: React.FC<ForeChartProps> = ({
         ...selectedExplanationData.map((d: { feature: string; importance: number; }) => Math.abs(d.importance))
     ) : 0;
 
-    const breakpoint = pastData.length;
+    const breakpoint = pastData.length - 1; // point to the last past data point
     const dataWithBounds = data.map((point, index) => {
         const newPoint = {...point};
 

--- a/gui-panel/src/components/Dashboard/AIDashboard.tsx
+++ b/gui-panel/src/components/Dashboard/AIDashboard.tsx
@@ -2,7 +2,7 @@ import {useLocation} from "react-router-dom";
 import {DashboardEntry, DashboardFolder, DashboardLayout} from "../../api/DataStructures";
 import React, {useEffect, useState} from "react";
 import Chart from "../Chart/Chart";
-import {simulateChartData} from "../../api/QuerySimulator";
+import {simulateChartData} from "../../api/DataFetcher";
 import FilterOptionsV2, {Filter} from "../Selectors/FilterOptions";
 import TimeSelector, {TimeFrame} from "../Selectors/TimeSelect";
 import PersistentDataManager from "../../api/PersistentDataManager";

--- a/gui-panel/src/components/Dashboard/Dashboard.tsx
+++ b/gui-panel/src/components/Dashboard/Dashboard.tsx
@@ -2,7 +2,7 @@ import {useParams} from 'react-router-dom';
 import React, {useEffect, useState} from "react";
 import {DashboardEntry, DashboardLayout} from "../../api/DataStructures";
 import Chart from "../Chart/Chart";
-import {simulateChartData} from "../../api/QuerySimulator";
+import {simulateChartData} from "../../api/DataFetcher";
 import FilterOptionsV2, {Filter} from "../Selectors/FilterOptions";
 import TimeSelector, {TimeFrame} from "../Selectors/TimeSelect";
 import PersistentDataManager from "../../api/PersistentDataManager";

--- a/gui-panel/src/components/DataView/DataView.tsx
+++ b/gui-panel/src/components/DataView/DataView.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from 'react';
 import Chart from '../Chart/Chart';
 import {KPI} from "../../api/DataStructures";
-import {simulateChartData} from "../../api/QuerySimulator";
+import {fetchData} from "../../api/DataFetcher";
 import FilterOptions, {Filter} from "../Selectors/FilterOptions";
 import {TimeFrame} from "../Selectors/TimeSelect"
 import PersistentDataManager from "../../api/PersistentDataManager";
@@ -21,7 +21,18 @@ const KpiSelector: React.FC<{
     setFilters: (filters: Filter) => void;
     onGenerate: () => void;
     dataManager: PersistentDataManager;
-}> = ({kpi, setKpi, timeFrame, setTimeFrame, graphType, setGraphType, filters, setFilters, onGenerate, dataManager}) => {
+}> = ({
+          kpi,
+          setKpi,
+          timeFrame,
+          setTimeFrame,
+          graphType,
+          setGraphType,
+          filters,
+          setFilters,
+          onGenerate,
+          dataManager
+      }) => {
     useEffect(() => {
         onGenerate();
     }, [kpi, timeFrame, graphType, filters]); // Dependencies to listen for changes
@@ -68,8 +79,8 @@ const DataView: React.FC = () => {
     const dataManager = PersistentDataManager.getInstance();
     const [kpi, setKpi] = useState<KPI>(dataManager.getKpiList()[0]);
     const [timeFrame, setTimeFrame] = useState<TimeFrame>({
-        from: new Date(2024, 3, 1),
-        to: new Date(2024, 10, 19),
+        from: new Date(2024, 2, 2),
+        to: new Date(2024, 9, 19),
         aggregation: "month"
     });
     const [graphType, setGraphType] = useState('pie');
@@ -81,7 +92,7 @@ const DataView: React.FC = () => {
     const fetchChartData = async () => {
         try {
             setLoading(true);
-            const data = await simulateChartData(kpi, timeFrame, graphType, filters);
+            const data = await fetchData(kpi, timeFrame, graphType, filters);
             setChartData(data);
         } catch (e) {
         } finally {

--- a/gui-panel/src/components/Forecast/Forecasting.tsx
+++ b/gui-panel/src/components/Forecast/Forecasting.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from "react";
 import PersistentDataManager from "../../api/PersistentDataManager";
-import {simulateChartData} from "../../api/QuerySimulator";
+import {fetchData, simulateChartData} from "../../api/DataFetcher";
 import FutureTimeFrameSelector from "./FutureTimeSelector";
 import {TimeFrame} from "../Selectors/TimeSelect";
 import KpiSelect from "../Selectors/KpiSelect";
@@ -140,7 +140,7 @@ const ForecastingPage: React.FC = () => {
         if (selectedKpi.id !== "none" && timeFrame !== null && selectedMachine.machineId !== "None Selected") {
             setLoading(true);
             const machineFilter = new Filter(selectedMachine.type, [selectedMachine.machineId]);
-            const pastData = await simulateChartData(selectedKpi, timeFrame.past, "line", machineFilter);
+            const pastData = await fetchData(selectedKpi, timeFrame.past, "line", machineFilter);
             const futureData = await simulateChartData(selectedKpi, timeFrame.future, "line", machineFilter);
             // Add default confidence value to each data point
             const combinedData = futureData.map(dataPoint => ({

--- a/gui-panel/src/components/Forecast/FutureTimeSelector.tsx
+++ b/gui-panel/src/components/Forecast/FutureTimeSelector.tsx
@@ -11,6 +11,8 @@ const FutureTimeFrameSelector: React.FC<FutureTimeFrameSelectorProps> = ({timeFr
     const getFutureTimeFrame = (days: number): TimeFrame => {
         const today = new Date();
         const from = new Date(today);
+        // avoid including today in the future period
+        from.setDate(from.getDate() + 1);
         const to = new Date(today.setDate(today.getDate() + days)); // After `days` days
         console.log("Future period:", from, to);
         return {from, to, aggregation: 'day'};
@@ -28,6 +30,7 @@ const FutureTimeFrameSelector: React.FC<FutureTimeFrameSelectorProps> = ({timeFr
     const getFutureWeekTimeFrame = (): TimeFrame => {
         const today = new Date();
         const from = new Date(today);
+        from.setDate(from.getDate() + 1); // Avoid including today in the future period
         const to = new Date(today.setDate(today.getDate() + 6)); // End of the next week
         console.log("Future week:", from, to);
         return {from, to, aggregation: 'day'};


### PR DESCRIPTION
If call to dummy is successful, kpi & machines are fetched from api.
For Data View, switch from simulated to real data.
For Forecasting, switched for past data but still needs to hardcode the today to last day in the dataset.

Reason for not including dashboards atm is because they currently locked in the present period, needs to override the today starting point, but hook will be straighforward.