### PR TITLE
Bunch of small graphic fixes

### DIFF
--- a/gui-panel/src/components/Chart/Chart.tsx
+++ b/gui-panel/src/components/Chart/Chart.tsx
@@ -295,7 +295,7 @@ const Chart: React.FC<ChartProps> = ({data, graphType, kpi, timeUnit = 'day'}) =
                             type="number"
                             tick={{fill: '#666'}}
                             domain={['dataMin', 'dataMax']}
-                            tickFormatter={(value) => value.toFixed(2)} // Precision limited to 2 decimal places
+                            tickFormatter={(value) =>  value >= 1 ? value.toFixed(2) : value.toExponential(2)} // Precision limited to 2 decimal places
                         />
                         <Tooltip content={<ScatterTooltip kpi={kpi}/>}/>
                         <Legend

--- a/gui-panel/src/components/Chart/ForecastingChart.tsx
+++ b/gui-panel/src/components/Chart/ForecastingChart.tsx
@@ -91,15 +91,7 @@ const ForeChart: React.FC<ForeChartProps> = ({
 
     const machineKey = futureDataEx?.machineName || "Machine";
     pastData = transformPastData(pastData, machineKey);
-    if (pastData.length > 0) {
-        // add a lower and upper bound to the last element of the past data so the line chart connects
-        pastData[pastData.length - 1] = {
-            ...pastData[pastData.length - 1],
-            lowerBound: pastData[pastData.length - 1].value,
-            upperBound: pastData[pastData.length - 1].value,
-        };
-    }
-    const data = [...pastData, ...futureData];
+    let data = [...pastData, ...futureData];
 
     if (!data || data.length === 0) {
         return <p style={{textAlign: "center", marginTop: "20px", color: "#555"}}>
@@ -121,6 +113,11 @@ const ForeChart: React.FC<ForeChartProps> = ({
     ) : 0;
 
     const breakpoint = pastData.length; // point to the last past data point
+    data = data.map((d) => ({
+        ...d,
+        numericTimestamp: new Date(d.timestamp).getTime(),
+    }));
+    console.log("Data:", data);
     return <div>
         {/* Forecasting Chart */}
         <ResponsiveContainer width="100%" height={400}>
@@ -134,14 +131,16 @@ const ForeChart: React.FC<ForeChartProps> = ({
             >
                 <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0"/>
                 <XAxis
-                    dataKey="timestamp"
+                    type="number"
+                    dataKey="numericTimestamp"
                     tick={{fill: "#666"}}
-                    tickFormatter={d => formatTimeFrame(d, timeUnit)}
+                    domain={["dataMin", "dataMax"]}
+                    tickFormatter={d => formatTimeFrame(new Date(d).toISOString(), timeUnit)}
                 />
                 <YAxis tick={{fill: "#666"}}/>
                 <Tooltip content={<ForecastTooltip kpi={kpi}/>} trigger={"hover"}/>
                 {data.length > 0 && <ReferenceLine
-                    x={data[breakpoint - 1].timestamp}
+                    x={new Date("2024-10-19").getTime()}
                     stroke="red"
                     label="Today"
                 />}

--- a/gui-panel/src/components/Chart/Tooltips.tsx
+++ b/gui-panel/src/components/Chart/Tooltips.tsx
@@ -19,7 +19,7 @@ export const DrillDownTooltip = ({active, payload, label, kpi}: any) => {
                     color: payload.fill,
                     margin: 0,
                     fontWeight: 'normal'
-                }}>{`${name}: ${payload[0].value} ${kpi?.unit || ''}`}</p>
+                }}>{`${name}: ${payload[0].value ? (payload[0].value >= 1 ? payload[0].value.toFixed(2) : payload[0].value.toExponential(2)) : 'N/A'} ${kpi?.unit || ''}`}</p>
             </div>
         );
     }
@@ -46,7 +46,7 @@ export const ScatterTooltip = ({active, payload, kpi}: any) => {
                         margin: 0,
                     }}
                 >
-                    {`${dataPoint.machineId}: ${dataPoint.y.toFixed(2)} ${
+                    {`${dataPoint.machineId}: ${dataPoint.y >= 1 ? dataPoint.y.toFixed(2) : dataPoint.y.toExponential(2)} ${
                         kpi?.unit || ''
                     }`}
                 </p>
@@ -77,7 +77,7 @@ export const LineTooltip = ({active, payload, label, kpi}: any) => {
                             color: entry.stroke, // Match the line's color
                         }}
                     >
-                        {`${entry.name}: ${entry.value.toFixed(2)} ${kpi?.unit || ''}`}
+                        {`${entry.name}: ${entry.value >= 1 ? entry.value.toFixed(2) : entry.value.toExponential(2)} ${kpi?.unit || ''}`}
                     </p>
                 ))}
             </div>

--- a/gui-panel/src/components/ChatAssistant/ChatAssistant.tsx
+++ b/gui-panel/src/components/ChatAssistant/ChatAssistant.tsx
@@ -142,8 +142,6 @@ const ChatAssistant: React.FC<ChatAssistantProps> = ({username, userId}) => {
         }, 60);
 
     }
-
-
     return (
         <div className="fixed bottom-1.5 right-2 z-50">
             {!isChatOpen && (

--- a/gui-panel/src/components/ChatAssistant/ChatComponents.tsx
+++ b/gui-panel/src/components/ChatAssistant/ChatComponents.tsx
@@ -114,7 +114,7 @@ const ExtraDataButtons: React.FC<ExtraDataProps> = ({extraData, onNavigate}) => 
             }
 
             {/* Explanation Button */}
-            {extraData.explanation && (
+            {extraData.explanation && extraData.explanation.length > 0 && (
                 <div>
                     <button
                         onClick={toggleExplanation}

--- a/gui-panel/src/components/Dashboard/Dashboard.tsx
+++ b/gui-panel/src/components/Dashboard/Dashboard.tsx
@@ -9,146 +9,165 @@ import PersistentDataManager from "../../api/DataManager";
 import {handleTimeAdjustments} from "../../utils/chartUtil";
 
 const Dashboard: React.FC = () => {
-    const dataManager = PersistentDataManager.getInstance();
-    const {dashboardId, dashboardPath} = useParams<{ dashboardId: string, dashboardPath: string }>();
-    const [dashboardData, setDashboardData] = useState<DashboardLayout>(new DashboardLayout("", "", []));
-    const [loading, setLoading] = useState(true);
-    const [chartData, setChartData] = useState<any[][]>([]);
-    const kpiList = dataManager.getKpiList(); // Cache KPI list once
-    const [filters, setFilters] = useState(new Filter("All", []));
-    const [timeFrame, setTimeFrame] = useState<TimeFrame>({
-        from: new Date(2024, 9, 10),
-        to: new Date(2024, 9, 19),
-        aggregation: 'day'
-    });
-    const [isRollbackTime, setIsRollbackTime] = useState(false);
+        const dataManager = PersistentDataManager.getInstance();
+        const {dashboardId, dashboardPath} = useParams<{ dashboardId: string, dashboardPath: string }>();
+        const [dashboardData, setDashboardData] = useState<DashboardLayout>(new DashboardLayout("", "", []));
+        const [loading, setLoading] = useState(true);
+        const [refreshing, setRefreshing] = useState(false);
+        const [chartData, setChartData] = useState<any[][]>([]);
+        const kpiList = dataManager.getKpiList(); // Cache KPI list once
+        const [filters, setFilters] = useState(new Filter("All", []));
+        const [timeFrame, setTimeFrame] = useState<TimeFrame>({
+            from: new Date(2024, 9, 16),
+            to: new Date(2024, 9, 19),
+            aggregation: 'day'
+        });
+        const [isRollbackTime, setIsRollbackTime] = useState(false);
 
-    //on first data load
-    useEffect(() => {
-        const fetchDashboardDataAndCharts = async () => {
-            try {
-                setLoading(true);
-                setFilters(new Filter("All", [])); // Reset filters
+        //on first data load
+        useEffect(() => {
+            const fetchDashboardDataAndCharts = async () => {
+                try {
+                    setLoading(true);
+                    setFilters(new Filter("All", [])); // Reset filters
 
-                await dataManager.waitUntilInitialized(); // Ensure initialization
-                // Fetch dashboard data by id
-                let dash = dataManager.findDashboardById(`${dashboardId}`, `${dashboardPath}`);
+                    await dataManager.waitUntilInitialized(); // Ensure initialization
+                    // Fetch dashboard data by id
+                    let dash = dataManager.findDashboardById(`${dashboardId}`, `${dashboardPath}`);
 
-                setDashboardData(dash);
+                    setDashboardData(dash);
 
-                let timeframe = handleTimeAdjustments(timeFrame, isRollbackTime);
+                    let timeframe = handleTimeAdjustments(timeFrame, isRollbackTime);
 
-                // Fetch chart data for each view
-                const chartDataPromises = dash.views.map(async (entry: DashboardEntry) => {
-                    const kpi = kpiList.find(k => k.id === entry.kpi);
+                    // Fetch chart data for each view
+                    const chartDataPromises = dash.views.map(async (entry: DashboardEntry) => {
+                        const kpi = kpiList.find(k => k.id === entry.kpi);
+                        if (!kpi) {
+                            console.error(`KPI with ID ${entry.kpi} not found.`);
+                            return [];
+                        }
+                        return await fetchData(kpi, timeframe, entry.graph_type, undefined); // Add appropriate filters
+                    });
+
+                    const resolvedChartData = await Promise.all(chartDataPromises);
+                    setChartData(resolvedChartData);
+                } catch (error) {
+                    console.error("Error fetching dashboard or chart data:", error);
+                } finally {
+                    setLoading(false);
+                }
+            };
+
+            fetchDashboardDataAndCharts();
+        }, [dashboardId, kpiList]);
+
+        useEffect(() => {
+                const fetchChartData = async () => {
+                    // Ensure promises are created dynamically based on latest dependencies
+                    const chartDataPromises = dashboardData.views.map(async (entry: DashboardEntry) => {
+                        const kpi = kpiList.find(k => k.id === entry.kpi);
+                        if (!kpi) {
+                            console.error(`KPI with ID ${entry.kpi} not found.`);
+                            return [];
+                        }
+                        let timeframe = handleTimeAdjustments(timeFrame, isRollbackTime);
+                        return await fetchData(kpi, timeframe, entry.graph_type, filters); // Add appropriate filters
+                    });
+                    setRefreshing(true);
+                    try {
+                        const resolvedChartData = await Promise.all(chartDataPromises);
+                        setChartData(resolvedChartData);
+                    } catch (error) {
+                        console.error("Error fetching chart data:", error);
+                    } finally {
+                        setRefreshing(false);
+                    }
+                };
+
+                // Avoid re-fetching during initial loading
+                if (!loading) {
+                    fetchChartData();
+                }
+            }, [filters, timeFrame, isRollbackTime]
+        );
+
+
+        if (loading) {
+            return <div className="flex flex-col justify-center items-center h-screen">
+                <div className="text-lg text-gray-600">Loading...</div>
+                <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-gray-500"></div>
+            </div>
+
+        }
+        return <div className="p-8 space-y-8 bg-gray-50 min-h-screen">
+
+            {/* Dashboard Title */}
+            <h1 className="text-3xl font-extrabold text-center text-gray-800">{dashboardData.name}</h1>
+            <div className="flex space-x-4">
+                <div><FilterOptionsV2 filter={filters} onChange={setFilters}/></div>
+                <div><TimeSelector timeFrame={timeFrame} setTimeFrame={setTimeFrame}/></div>
+                <div>
+                    <label htmlFor="timeRollback" className="text-gray-700">Back to last data available</label>
+                    <input
+                        type="checkbox"
+                        id="timeRollback"
+                        name="timeRollback"
+                        checked={isRollbackTime}
+                        onChange={() => setIsRollbackTime(!isRollbackTime)}
+                        className="ml-2"
+                    />
+                </div>
+            </div>
+            {/* Refreshing indicator */}
+            {refreshing && (
+                <div className="fixed inset-0 bg-gray-800 bg-opacity-50 flex justify-center items-center">
+                    <div className="flex flex-col items-center bg-white p-8 rounded-lg shadow-lg">
+                        <div className="text-lg text-gray-800 mb-4">Updating Charts...</div>
+                        <div
+                            className="flex justify-center items-center animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-gray-500"></div>
+                    </div>
+                </div>
+            )}
+            {/* Grid Layout */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-8 items-center w-f">
+                {dashboardData.views.map((entry: DashboardEntry, index: number) => {
+                    let kpi = kpiList.find(k => k.id === entry.kpi);
                     if (!kpi) {
                         console.error(`KPI with ID ${entry.kpi} not found.`);
-                        return [];
+                        return null;
                     }
-                    return await fetchData(kpi, timeframe, entry.graph_type, undefined); // Add appropriate filters
-                });
 
-                const resolvedChartData = await Promise.all(chartDataPromises);
-                setChartData(resolvedChartData);
-            } catch (error) {
-                console.error("Error fetching dashboard or chart data:", error);
-            } finally {
-                setLoading(false);
-            }
-        };
+                    // Determine grid layout based on chart type
+                    const isSmallCard = entry.graph_type === 'pie' || entry.graph_type === 'donut';
 
-        fetchDashboardDataAndCharts();
-    }, [dashboardId, kpiList]);
+                    // Dynamic grid class
+                    const gridClass = isSmallCard
+                        ? 'sm:col-span-1 lg:col-span-1' // Small cards fit three in a row
+                        : 'col-span-auto '; // Bar and Pie charts share rows;
 
-    useEffect(() => {
-        const fetchChartData = async () => {
-            // Ensure promises are created dynamically based on latest dependencies
-            const chartDataPromises = dashboardData.views.map(async (entry: DashboardEntry) => {
-                const kpi = kpiList.find(k => k.id === entry.kpi);
-                if (!kpi) {
-                    console.error(`KPI with ID ${entry.kpi} not found.`);
-                    return [];
-                }
-                let timeframe = handleTimeAdjustments(timeFrame, isRollbackTime);
-                return await fetchData(kpi, timeframe, entry.graph_type, filters); // Add appropriate filters
-            });
+                    return <div
+                        key={index}
+                        className={`bg-white shadow-lg rounded-xl p-6 border border-gray-200 hover:shadow-xl transition-shadow ${gridClass}`}
+                    >
+                        {/* KPI Title */}
+                        <h3 className="text-xl font-semibold text-gray-700 mb-6 text-center">
+                            {kpi?.name}
+                        </h3>
 
-            const resolvedChartData = await Promise.all(chartDataPromises);
-            setChartData(resolvedChartData);
-        };
-
-        // Avoid fetching during initial loading
-        if (!loading) {
-            fetchChartData();
-        }
-    }, [filters, timeFrame, isRollbackTime]);
-
-
-    if (loading) {
-        return <div className="flex flex-col justify-center items-center h-screen">
-            <div className="text-lg text-gray-600">Loading...</div>
-            <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-gray-500"></div>
-        </div>
-
-    }
-    return <div className="p-8 space-y-8 bg-gray-50 min-h-screen">
-
-        {/* Dashboard Title */}
-        <h1 className="text-3xl font-extrabold text-center text-gray-800">{dashboardData.name}</h1>
-        <div className="flex space-x-4">
-            <div><FilterOptionsV2 filter={filters} onChange={setFilters}/></div>
-            <div><TimeSelector timeFrame={timeFrame} setTimeFrame={setTimeFrame}/></div>
-            <div>
-                <label htmlFor="timeRollback" className="text-gray-700">Back to last data available</label>
-                <input
-                    type="checkbox"
-                    id="timeRollback"
-                    name="timeRollback"
-                    checked={isRollbackTime}
-                    onChange={() => setIsRollbackTime(!isRollbackTime)}
-                    className="ml-2"
-                />
+                        {/* Chart */}
+                        <div className="flex items-center justify-center">
+                            <Chart
+                                data={chartData[index]} // Pass the fetched chart data
+                                graphType={entry.graph_type}
+                                kpi={kpi}
+                                timeUnit={timeFrame.aggregation}
+                            />
+                        </div>
+                    </div>;
+                })}
             </div>
-        </div>
-        {/* Grid Layout */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-8 items-center w-f">
-            {dashboardData.views.map((entry: DashboardEntry, index: number) => {
-                let kpi = kpiList.find(k => k.id === entry.kpi);
-                if (!kpi) {
-                    console.error(`KPI with ID ${entry.kpi} not found.`);
-                    return null;
-                }
-
-                // Determine grid layout based on chart type
-                const isSmallCard = entry.graph_type === 'pie' || entry.graph_type === 'donut';
-
-                // Dynamic grid class
-                const gridClass = isSmallCard
-                    ? 'sm:col-span-1 lg:col-span-1' // Small cards fit three in a row
-                    : 'col-span-auto '; // Bar and Pie charts share rows;
-
-                return <div
-                    key={index}
-                    className={`bg-white shadow-lg rounded-xl p-6 border border-gray-200 hover:shadow-xl transition-shadow ${gridClass}`}
-                >
-                    {/* KPI Title */}
-                    <h3 className="text-xl font-semibold text-gray-700 mb-6 text-center">
-                        {kpi?.name}
-                    </h3>
-
-                    {/* Chart */}
-                    <div className="flex items-center justify-center">
-                        <Chart
-                            data={chartData[index]} // Pass the fetched chart data
-                            graphType={entry.graph_type}
-                            kpi={kpi}
-                            timeUnit={timeFrame.aggregation}
-                        />
-                    </div>
-                </div>;
-            })}
-        </div>
-    </div>;
-};
+        </div>;
+    }
+;
 
 export default Dashboard;

--- a/gui-panel/src/components/DataView/DataView.tsx
+++ b/gui-panel/src/components/DataView/DataView.tsx
@@ -84,15 +84,18 @@ const DataView: React.FC = () => {
     const [filters, setFilters] = useState<Filter>(new Filter('All', []));
     const [chartData, setChartData] = useState<any[]>([]);
     const [loading, setLoading] = useState(false);
+    // Used to store the last used chart type and not sync the chart to the selected one before the new data is fetched
+    const [usedChartType, setUsedChartType] = useState('pie');
     // Function to fetch chart data with applied filters
 
     const fetchChartData = async () => {
         try {
             setLoading(true);
-
+            //sync the chart type with the last used one
+            setGraphType(usedChartType);
             // if one of the parameters is not set, return
             if (kpi && timeFrame && graphType && DataManager.getInstance().getMachineList()) {
-                const data = await fetchData(kpi, timeFrame, graphType, filters);
+                const data = await fetchData(kpi, timeFrame, usedChartType, filters);
                 setChartData(data);
             }
         } catch (e) {
@@ -109,8 +112,8 @@ const DataView: React.FC = () => {
                 setKpi={setKpi}
                 timeFrame={timeFrame}
                 setTimeFrame={setTimeFrame}
-                graphType={graphType}
-                setGraphType={setGraphType}
+                graphType={usedChartType}
+                setGraphType={setUsedChartType}
                 filters={filters}
                 setFilters={setFilters}
                 onGenerate={fetchChartData} // Fetch chart data when "Generate" button is clicked

--- a/gui-panel/src/components/Selectors/AdvancedTimeSelect.tsx
+++ b/gui-panel/src/components/Selectors/AdvancedTimeSelect.tsx
@@ -10,8 +10,8 @@ const TimeFrameSelector: React.FC<TimeFrameSelectorProps> = ({timeFrame, setTime
         const diffInDays = diffInMs / (1000 * 60 * 60 * 24);
 
         if (diffInDays > 90) return 'month';
-        if (diffInDays > 30) return 'day';
-        return 'hour';
+        if (diffInDays > 30) return 'week';
+        return 'day';
     };
 
     const isValidDate = (dateString: string): boolean => {

--- a/gui-panel/src/components/UserSettings/UserSettings.tsx
+++ b/gui-panel/src/components/UserSettings/UserSettings.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
-import { changePassword } from '../../api/ApiService';
-import { hashPassword } from '../../api/security/securityService';
+import React, {useState} from 'react';
+import {changePassword} from '../../api/ApiService';
+import {hashPassword} from '../../api/security/securityService';
 
 interface UserSettingsProps {
   userId: string;
@@ -19,8 +19,8 @@ const UserSettings: React.FC<UserSettingsProps> = ({ userId, username, token, ro
   const [passwordChangeSuccess, setPasswordChangeSuccess] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
 
-  const [firstName, setFirstName] = useState("John");
-  const [lastName, setLastName] = useState("Doe");
+  const [firstName, setFirstName] = useState(" ");
+  const [lastName, setLastName] = useState(" ");
 
   const handleSubmit = () => {
     // Send data to API
@@ -64,7 +64,7 @@ const UserSettings: React.FC<UserSettingsProps> = ({ userId, username, token, ro
       const hashedNewPassword = await hashPassword(newPassword);
       await changePassword(userId, hashedOldPassword, hashedNewPassword);
       console.log(userId, hashedOldPassword, hashedNewPassword);
-      //await changePassword(userId, username, token, role, site, await hashPassword(oldPassword), await hashPassword(newPassword));
+      await changePassword(userId, await hashPassword(oldPassword), await hashPassword(newPassword));
       setPasswordChangeSuccess(true);
       // Dopo un breve delay, chiudiamo il dialog
       setTimeout(() => {
@@ -129,6 +129,7 @@ const UserSettings: React.FC<UserSettingsProps> = ({ userId, username, token, ro
                 id="email"
                 className="w-fit p-3 border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
                 defaultValue={email}
+                readOnly={true}
             />
           </div>
 


### PR DESCRIPTION
Makes numbers on tooltips use exponential notation if below 1, makes sure the today line is always on the 19th in forecasting.
Added description in Forecasting for Lime
Data View's chart selection doesn't directly change the chart anymore, as it was leading to errors, prev value is cached and replaced on new data fetch